### PR TITLE
avoid download multiple times

### DIFF
--- a/models/backbone.py
+++ b/models/backbone.py
@@ -11,7 +11,7 @@ from torch import nn
 from torchvision.models._utils import IntermediateLayerGetter
 from typing import Dict, List
 
-from util.misc import NestedTensor
+from util.misc import NestedTensor, get_rank
 
 from .position_encoding import build_position_encoding
 
@@ -88,7 +88,7 @@ class Backbone(BackboneBase):
                  dilation: bool):
         backbone = getattr(torchvision.models, name)(
             replace_stride_with_dilation=[False, False, dilation],
-            pretrained=True, norm_layer=FrozenBatchNorm2d)
+            pretrained=get_rank()==0, norm_layer=FrozenBatchNorm2d)
         num_channels = 512 if name in ('resnet18', 'resnet34') else 2048
         super().__init__(backbone, train_backbone, num_channels, return_interm_layers)
 


### PR DESCRIPTION
fix the bug:

download the pretrained model multiple times, which is unnecessary and time-consuming.