### PR TITLE
improve robustness of plot_logs function, handle single directory argument for 'logs' param

### DIFF
--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -11,7 +11,7 @@ from pathlib import Path, PurePath
 
 def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):
     '''
-    Function to plot specific fields from training log(s). Plots both training and test results.  
+    Function to plot specific fields from training log(s). Plots both training and test results.
 
     :: Inputs - logs = list containing Path objects, each pointing to individual dir with a log file
               - fields = which results to plot from each log file - plots both training and test for each field.

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -13,14 +13,14 @@ import copy
 
 
 def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):
-    ''' 
-    Function to plot specific fields from training logs     
+    '''
+    Function to plot specific fields from training logs 
     :: Inputs - logs = list containing one or more directories, each w/ single log file (convert to list if needed)
               - fields = which training results to plot from log file
               - ewm_col = ??
-              - log_name = optional, name for log file(s) if different than default 'log.txt'.             
+              - log_name = optional, name for log file(s) if different than default 'log.txt'            
     :: Outputs - matplotlib plots of items in fields per each log file.
-               - solid lines are training results, dashed lines are test results.       
+               - solid lines are training results, dashed lines are test results
     '''
 
     # verify logs is list, convert if not. handle single dir, etc. *Should not have side-effects, makes deep new logs

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -14,11 +14,11 @@ import copy
 
 def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):
     '''
-    Function to plot specific fields from training logs 
+    Function to plot specific fields from training logs
     :: Inputs - logs = list containing one or more directories, each w/ single log file (convert to list if needed)
               - fields = which training results to plot from log file
               - ewm_col = ??
-              - log_name = optional, name for log file(s) if different than default 'log.txt'            
+              - log_name = optional, name for log file(s) if different than default 'log.txt'
     :: Outputs - matplotlib plots of items in fields per each log file.
                - solid lines are training results, dashed lines are test results
     '''
@@ -95,3 +95,4 @@ def plot_precision_recall(files, naming_scheme='iter'):
     axs[1].set_title('Scores / Recall')
     axs[1].legend(names)
     return fig, axs
+    

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -11,7 +11,8 @@ from pathlib import Path, PurePath
 from typing import Iterable
 import copy
 
-def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):  
+
+def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):
     ''' 
     Function to plot specific fields from training logs     
     :: Inputs - logs = list containing one or more directories, each w/ single log file (convert to list if needed)
@@ -21,25 +22,25 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
     :: Outputs - matplotlib plots of items in fields per each log file.
                - solid lines are training results, dashed lines are test results.       
     '''
-    
-    # verify logs is list, convert if not. handle single dir, etc. *Should not have side-effects, makes deep new logs     
+
+    # verify logs is list, convert if not. handle single dir, etc. *Should not have side-effects, makes deep new logs
     if not isinstance(logs, list):
         if not isinstance(logs, Iterable):
             logs = [logs]
         else:
             logs = copy.deepcopy(list(logs))
-        print(f"info only - plot_utils::plot_logs - logs argument expects list.")   
-    
-    
-    # verify valid dir(s)   
-    for i,dir in enumerate(logs):
+        print("info only - plot_utils::plot_logs - logs argument expects list, received.")
+
+    # verify valid dir(s)
+    for i, dir in enumerate(logs):
         if not isinstance(dir, PurePath):
             dir = Path(dir)
         if dir.exists():
             continue
-        raise ValueError(f"plot_utils::plot_logs - invalid directory in logs argument:\n{Path(dir)}")       
-                           
-    # load log file(s) and plot   
+        raise ValueError(
+            f"plot_utils::plot_logs - invalid directory in logs argument:\n{Path(dir)}")
+
+    # load log file(s) and plot
     dfs = [pd.read_json(Path(p) / log_name, lines=True) for p in logs]
 
     fig, axs = plt.subplots(ncols=len(fields), figsize=(16, 5))
@@ -47,7 +48,8 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
     for df, color in zip(dfs, sns.color_palette(n_colors=len(logs))):
         for j, field in enumerate(fields):
             if field == 'mAP':
-                coco_eval = pd.DataFrame(pd.np.stack(df.test_coco_eval.dropna().values)[:, 1]).ewm(com=ewm_col).mean()
+                coco_eval = pd.DataFrame(pd.np.stack(df.test_coco_eval.dropna().values)[
+                                         :, 1]).ewm(com=ewm_col).mean()
                 axs[j].plot(coco_eval, c=color)
             else:
                 df.interpolate().ewm(com=ewm_col).mean().plot(

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -8,8 +8,9 @@ import matplotlib.pyplot as plt
 
 from pathlib import Path, PurePath
 
+
 def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):
-    ''' 
+    '''
     Function to plot specific fields from training log(s). Plots both training and test results.  
 
     :: Inputs - logs = list containing Path objects, each pointing to individual dir with a log file

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -4,13 +4,54 @@ Plotting utilities to visualize training logs.
 """
 import torch
 import pandas as pd
-from pathlib import Path
 import seaborn as sns
 import matplotlib.pyplot as plt
 
+from pathlib import Path, PurePath
+from typing import Iterable
+import copy
 
-def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0):
-    dfs = [pd.read_json(Path(p) / 'log.txt', lines=True) for p in logs]
+
+def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):
+    
+    ''' 
+    Function to plot specific fields from training logs  
+    
+    :: Inputs - logs = list containing one or more directories, each with single log file (will convert to list if needed)
+              - fields = which training results to plot from log file
+              - ewm_col = ??
+              - log_name = optional, name for log file(s) if different than default 'log.txt'.
+              
+    :: Outputs - matplotlib plots of items in fields per each log file.
+               - solid lines are training results, dashed lines are test results.
+        
+    '''
+    
+    # verify logs is list, convert if not - handles single dir, etc.  *Should not have side-effects, new logs list is made 
+    
+    if not isinstance(logs, list):
+        if not isinstance(logs, Iterable):
+            logs = [logs]
+        else:
+            logs = copy.deepcopy(list(logs))
+        print(f"info only - plot_utils::plot_logs - logs argument expects list.")
+    
+    
+    
+    # verify valid dir(s)
+    
+    for i,dir in enumerate(logs):
+        if not isinstance(dir, PurePath):
+            dir = Path(dir)
+        if dir.exists():
+            continue
+        raise ValueError(f"plot_utils::plot_logs - invalid directory in logs argument:\n{Path(dir)}")
+        
+                
+            
+    # load log file(s) and plot
+    
+    dfs = [pd.read_json(Path(p) / log_name, lines=True) for p in logs]
 
     fig, axs = plt.subplots(ncols=len(fields), figsize=(16, 5))
 

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -95,4 +95,3 @@ def plot_precision_recall(files, naming_scheme='iter'):
     axs[1].set_title('Scores / Recall')
     axs[1].legend(names)
     return fig, axs
-    

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -11,46 +11,35 @@ from pathlib import Path, PurePath
 from typing import Iterable
 import copy
 
-
-def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):
-    
+def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):  
     ''' 
-    Function to plot specific fields from training logs  
-    
-    :: Inputs - logs = list containing one or more directories, each with single log file (will convert to list if needed)
+    Function to plot specific fields from training logs     
+    :: Inputs - logs = list containing one or more directories, each w/ single log file (convert to list if needed)
               - fields = which training results to plot from log file
               - ewm_col = ??
-              - log_name = optional, name for log file(s) if different than default 'log.txt'.
-              
+              - log_name = optional, name for log file(s) if different than default 'log.txt'.             
     :: Outputs - matplotlib plots of items in fields per each log file.
-               - solid lines are training results, dashed lines are test results.
-        
+               - solid lines are training results, dashed lines are test results.       
     '''
     
-    # verify logs is list, convert if not - handles single dir, etc.  *Should not have side-effects, new logs list is made 
-    
+    # verify logs is list, convert if not. handle single dir, etc. *Should not have side-effects, makes deep new logs     
     if not isinstance(logs, list):
         if not isinstance(logs, Iterable):
             logs = [logs]
         else:
             logs = copy.deepcopy(list(logs))
-        print(f"info only - plot_utils::plot_logs - logs argument expects list.")
+        print(f"info only - plot_utils::plot_logs - logs argument expects list.")   
     
     
-    
-    # verify valid dir(s)
-    
+    # verify valid dir(s)   
     for i,dir in enumerate(logs):
         if not isinstance(dir, PurePath):
             dir = Path(dir)
         if dir.exists():
             continue
-        raise ValueError(f"plot_utils::plot_logs - invalid directory in logs argument:\n{Path(dir)}")
-        
-                
-            
-    # load log file(s) and plot
-    
+        raise ValueError(f"plot_utils::plot_logs - invalid directory in logs argument:\n{Path(dir)}")       
+                           
+    # load log file(s) and plot   
     dfs = [pd.read_json(Path(p) / log_name, lines=True) for p in logs]
 
     fig, axs = plt.subplots(ncols=len(fields), figsize=(16, 5))


### PR DESCRIPTION
- robustify logs parameter: checks if arg is list, if not, deep converts to list for plotting (deep convert to avoid side effects).
- expose log name as optional param (log_name = 'log.txt') to avoid internal hard-coded references
- verify directories passed in are valid.  Raise ValueError if not with path to broken directory shown
- added parameter explanations in comments

Note - directory check is totally optional, comments are optional.  
Core fix was really to handle single directory being passed in which was my direct use case failure and hence this PR.  