### PR TITLE
support new args.num_classes for custom training, robustly and with full back-compat

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,8 +29,11 @@ def get_args_parser():
                         help='gradient clipping max norm')
 
     # Model parameters
+    parser.add_argument('--num_classes', type=int, default=20,
+                        help="Number of classes in your dataset. Overridden by coco and coco_panoptic datasets")
     parser.add_argument('--frozen_weights', type=str, default=None,
                         help="Path to the pretrained model. If set, only the mask head will be trained")
+                        
     # * Backbone
     parser.add_argument('--backbone', default='resnet50', type=str,
                         help="Name of the convolutional backbone to use")

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def get_args_parser():
                         help="Number of classes in your dataset. Overridden by coco and coco_panoptic datasets")
     parser.add_argument('--frozen_weights', type=str, default=None,
                         help="Path to the pretrained model. If set, only the mask head will be trained")
-                        
+
     # * Backbone
     parser.add_argument('--backbone', default='resnet50', type=str,
                         help="Name of the convolutional backbone to use")

--- a/models/detr.py
+++ b/models/detr.py
@@ -20,6 +20,7 @@ from .transformer import build_transformer
 
 class DETR(nn.Module):
     """ This is the DETR module that performs object detection """
+
     def __init__(self, backbone, transformer, num_classes, num_queries, aux_loss=False):
         """ Initializes the model.
         Parameters:
@@ -86,6 +87,7 @@ class SetCriterion(nn.Module):
         1) we compute hungarian assignment between ground truth boxes and the outputs of the model
         2) we supervise each pair of matched ground-truth / prediction (supervise class and box)
     """
+
     def __init__(self, num_classes, matcher, weight_dict, eos_coef, losses):
         """ Create the criterion.
         Parameters:
@@ -302,9 +304,28 @@ class MLP(nn.Module):
 
 
 def build(args):
-    num_classes = 20 if args.dataset_file != 'coco' else 91
-    if args.dataset_file == "coco_panoptic":
+    '''
+    Builds a DETR model and supporting criterion and postprocessor
+
+    Inputs: args (from main.py)
+
+    Outputs:  - model = DETR detection model
+              - criterion = loss evaluations for bboxes, labels, cardinality
+              - postprocessor = for bbox and optionally segmentation
+
+    '''
+    try:
+        num_classes = args.num_classes
+    except:
+        num_classes = 20  # default to 20 for backwards compat if missing args.num_classes
+
+    # over-ride num_classes for known datasets:
+    if args.dataset_file == 'coco':
+        num_classes = 91
+
+    if args.dataset_file == 'coco_panoptic':
         num_classes = 250
+
     device = torch.device(args.device)
 
     backbone = build_backbone(args)

--- a/models/detr.py
+++ b/models/detr.py
@@ -316,7 +316,7 @@ def build(args):
     '''
     try:
         num_classes = args.num_classes
-    except:
+    except AttributeError:
         num_classes = 20  # default to 20 for backwards compat if missing args.num_classes
 
     # over-ride num_classes for known datasets:


### PR DESCRIPTION
This PR attempts to cleanly integrate a new args.num_classes support for custom datasets while keeping full backwards compatibility.
1 - a new args.num_classes is made in main.py, with a default of 20 for backward compat with previous code in detr::build(args) which defaulted to 20.

2 - detr::build(args) is updated to safely check for the presence of a args.num_classes.  If found that num_classes is used. 
If not present, num_classes is set to 20, as before.  

{ I wrappered this check for args.num_classes in a try/except block because likely people already have modified main.py scripts (I did) that won't have args.num_classes present. 
I tested and found that checking for args.num_classes is None, my first instinct, will throw an exception if args.num_classes does not exist, hence the try/except block is required.. }

3 - datasets coco and coco_panoptic are checked via args.dataset_file as previously, and num_classes is over-ridden if so and set as before. 