### PR TITLE
Changed incorrect bbox format in loss_bbox docstring

### DIFF
--- a/models/detr.py
+++ b/models/detr.py
@@ -143,7 +143,7 @@ class SetCriterion(nn.Module):
     def loss_boxes(self, outputs, targets, indices, num_boxes):
         """Compute the losses related to the bounding boxes, the L1 regression loss and the GIoU loss
            targets dicts must contain the key "boxes" containing a tensor of dim [nb_target_boxes, 4]
-           The target boxes are expected in format (center_x, center_y, h, w), normalized by the image size.
+           The target boxes are expected in format (center_x, center_y, w, h), normalized by the image size.
         """
         assert 'pred_boxes' in outputs
         idx = self._get_src_permutation_idx(indices)


### PR DESCRIPTION
(center_x, center_y, h, w) changed to (center_x, center_y, w, h) as requested by @fmassa in #75 