### PR TITLE
Add back support for 4d tensors

### DIFF
--- a/models/detr.py
+++ b/models/detr.py
@@ -56,7 +56,7 @@ class DETR(nn.Module):
                - "aux_outputs": Optional, only returned when auxilary losses are activated. It is a list of
                                 dictionnaries containing the two above keys for each decoder layer.
         """
-        if isinstance(samples, list):
+        if isinstance(samples, (list, torch.Tensor)):
             samples = nested_tensor_from_tensor_list(samples)
         features, pos = self.backbone(samples)
 

--- a/test_all.py
+++ b/test_all.py
@@ -78,6 +78,21 @@ class Tester(unittest.TestCase):
         self.assertTrue(out["pred_boxes"].equal(out_script["pred_boxes"]))
         self.assertTrue(out["pred_masks"].equal(out_script["pred_masks"]))
 
+    def test_model_detection_different_inputs(self):
+        model = detr_resnet50(pretrained=False).eval()
+        # support NestedTensor
+        x = nested_tensor_from_tensor_list([torch.rand(3, 200, 200), torch.rand(3, 200, 250)])
+        out = model(x)
+        self.assertIn('pred_logits', out)
+        # and 4d Tensor
+        x = torch.rand(1, 3, 200, 200)
+        out = model(x)
+        self.assertIn('pred_logits', out)
+        # and List[Tensor[C, H, W]]
+        x = torch.rand(3, 200, 200)
+        out = model([x])
+        self.assertIn('pred_logits', out)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/detr/issues/122

This was a side-effect introduced in https://github.com/facebookresearch/detr/pull/119. Indeed, support for 4d tensors was implicit in the implementation, let's make it explicit now and add a test.