### PR TITLE
Make util imports relative in /models

### DIFF
--- a/models/backbone.py
+++ b/models/backbone.py
@@ -11,7 +11,7 @@ from torch import nn
 from torchvision.models._utils import IntermediateLayerGetter
 from typing import Dict, List
 
-from util.misc import NestedTensor, is_main_process
+from ..util.misc import NestedTensor, is_main_process
 
 from .position_encoding import build_position_encoding
 

--- a/models/detr.py
+++ b/models/detr.py
@@ -6,8 +6,8 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from util import box_ops
-from util.misc import (NestedTensor, nested_tensor_from_tensor_list,
+from .util import box_ops
+from .util.misc import (NestedTensor, nested_tensor_from_tensor_list,
                        accuracy, get_world_size, interpolate,
                        is_dist_avail_and_initialized)
 

--- a/models/detr.py
+++ b/models/detr.py
@@ -6,8 +6,8 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from .util import box_ops
-from .util.misc import (NestedTensor, nested_tensor_from_tensor_list,
+from ..util import box_ops
+from ..util.misc import (NestedTensor, nested_tensor_from_tensor_list,
                        accuracy, get_world_size, interpolate,
                        is_dist_avail_and_initialized)
 

--- a/models/matcher.py
+++ b/models/matcher.py
@@ -6,7 +6,7 @@ import torch
 from scipy.optimize import linear_sum_assignment
 from torch import nn
 
-from util.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
+from ..util.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
 
 
 class HungarianMatcher(nn.Module):

--- a/models/position_encoding.py
+++ b/models/position_encoding.py
@@ -6,7 +6,7 @@ import math
 import torch
 from torch import nn
 
-from util.misc import NestedTensor
+from ..util.misc import NestedTensor
 
 
 class PositionEmbeddingSine(nn.Module):

--- a/models/segmentation.py
+++ b/models/segmentation.py
@@ -12,8 +12,8 @@ import torch.nn.functional as F
 from torch import Tensor
 from PIL import Image
 
-import util.box_ops as box_ops
-from util.misc import NestedTensor, interpolate, nested_tensor_from_tensor_list
+import ..util.box_ops as box_ops
+from ..util.misc import NestedTensor, interpolate, nested_tensor_from_tensor_list
 
 try:
     from panopticapi.utils import id2rgb, rgb2id


### PR DESCRIPTION
Greetings,

This is just a small tweak to allow importing components without error about util. I had to tweak this to use the model components when cloning the dir.

Thanks for the great work!

