### PR TITLE
[fix] type of images in D2/DETR

### DIFF
--- a/d2/detr/detr.py
+++ b/d2/detr/detr.py
@@ -37,7 +37,7 @@ class MaskedBackbone(nn.Module):
         self.num_channels = backbone_shape[list(backbone_shape.keys())[-1]].channels
 
     def forward(self, images):
-        features = self.backbone(images.tensor)
+        features = self.backbone(images.tensors)
         masks = self.mask_out_padding(
             [features_per_level.shape for features_per_level in features.values()],
             images.image_sizes,


### PR DESCRIPTION
If DETR is run on d2 folder, `images` is `NestedTesnor`.

Hence, check the type of `images` whether it is `NestedTensor` or `ImageList` and change following lines for each type.

Related Issue: #136 