### PR TITLE
Fix ONNX export for panotpic model

### DIFF
--- a/models/segmentation.py
+++ b/models/segmentation.py
@@ -164,7 +164,7 @@ class MHAttentionMap(nn.Module):
 
         if mask is not None:
             weights.masked_fill_(mask.unsqueeze(1).unsqueeze(1), float("-inf"))
-        weights = F.softmax(weights.flatten(2), dim=-1).view_as(weights)
+        weights = F.softmax(weights.flatten(2), dim=-1).view(weights.size())
         weights = self.dropout(weights)
         return weights
 

--- a/test_all.py
+++ b/test_all.py
@@ -167,6 +167,7 @@ class ONNXExporterTester(unittest.TestCase):
             tolerate_small_mismatch=True,
         )
 
+    @unittest.skip("CI doesn't have enough memory")
     def test_model_onnx_detection_panoptic(self):
         model = detr_resnet50_panoptic(pretrained=False).eval()
         dummy_image = torch.ones(1, 3, 800, 800) * 0.3

--- a/test_all.py
+++ b/test_all.py
@@ -166,7 +166,7 @@ class ONNXExporterTester(unittest.TestCase):
             output_names=["pred_logits", "pred_boxes"],
             tolerate_small_mismatch=True,
         )
-        
+
     def test_model_onnx_detection_panoptic(self):
         model = detr_resnet50_panoptic(pretrained=False).eval()
         dummy_image = torch.ones(1, 3, 800, 800) * 0.3

--- a/test_all.py
+++ b/test_all.py
@@ -166,7 +166,20 @@ class ONNXExporterTester(unittest.TestCase):
             output_names=["pred_logits", "pred_boxes"],
             tolerate_small_mismatch=True,
         )
+        
+    def test_model_onnx_detection_panoptic(self):
+        model = detr_resnet50_panoptic(pretrained=False).eval()
+        dummy_image = torch.ones(1, 3, 800, 800) * 0.3
+        model(dummy_image)
 
+        # Test exported model on images of different size, or dummy input
+        self.run_model(
+            model,
+            [(torch.rand(1, 3, 750, 800),)],
+            input_names=["inputs"],
+            output_names=["pred_logits", "pred_boxes", "pred_masks"],
+            tolerate_small_mismatch=True,
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_all.py
+++ b/test_all.py
@@ -181,5 +181,6 @@ class ONNXExporterTester(unittest.TestCase):
             tolerate_small_mismatch=True,
         )
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The operation `.view_as(an_other_tensor)` is not supported by ONNX.
`view(an_other_tensor.size())` is identical and supported, this fix allow to export panoptic models.