### PR TITLE
Plot utils updates - futureproof, avoid crashing if log not written yet

### DIFF
--- a/models/detr.py
+++ b/models/detr.py
@@ -20,6 +20,7 @@ from .transformer import build_transformer
 
 class DETR(nn.Module):
     """ This is the DETR module that performs object detection """
+
     def __init__(self, backbone, transformer, num_classes, num_queries, aux_loss=False):
         """ Initializes the model.
         Parameters:
@@ -86,6 +87,7 @@ class SetCriterion(nn.Module):
         1) we compute hungarian assignment between ground truth boxes and the outputs of the model
         2) we supervise each pair of matched ground-truth / prediction (supervise class and box)
     """
+
     def __init__(self, num_classes, matcher, weight_dict, eos_coef, losses):
         """ Create the criterion.
         Parameters:
@@ -302,9 +304,28 @@ class MLP(nn.Module):
 
 
 def build(args):
-    num_classes = 20 if args.dataset_file != 'coco' else 91
-    if args.dataset_file == "coco_panoptic":
+    '''
+    Builds a DETR model and supporting criterion and postprocessor
+
+    Inputs: args (from main.py)
+
+    Outputs:  - model = DETR detection model
+              - criterion = loss evaluations for bboxes, labels, cardinality
+              - postprocessor = for bbox and optionally segmentation
+
+    '''
+    try:
+        num_classes = args.num_classes
+    except:
+        num_classes = 20  # default to 20 for backwards compat if missing args.num_classes
+
+    # over-ride num_classes for known datasets:
+    if args.dataset_file == 'coco':
+        num_classes = 91
+
+    if args.dataset_file == 'coco_panoptic':
         num_classes = 250
+
     device = torch.device(args.device)
 
     backbone = build_backbone(args)

--- a/models/detr.py
+++ b/models/detr.py
@@ -20,7 +20,6 @@ from .transformer import build_transformer
 
 class DETR(nn.Module):
     """ This is the DETR module that performs object detection """
-
     def __init__(self, backbone, transformer, num_classes, num_queries, aux_loss=False):
         """ Initializes the model.
         Parameters:
@@ -87,7 +86,6 @@ class SetCriterion(nn.Module):
         1) we compute hungarian assignment between ground truth boxes and the outputs of the model
         2) we supervise each pair of matched ground-truth / prediction (supervise class and box)
     """
-
     def __init__(self, num_classes, matcher, weight_dict, eos_coef, losses):
         """ Create the criterion.
         Parameters:
@@ -304,28 +302,9 @@ class MLP(nn.Module):
 
 
 def build(args):
-    '''
-    Builds a DETR model and supporting criterion and postprocessor
-
-    Inputs: args (from main.py)
-
-    Outputs:  - model = DETR detection model
-              - criterion = loss evaluations for bboxes, labels, cardinality
-              - postprocessor = for bbox and optionally segmentation
-
-    '''
-    try:
-        num_classes = args.num_classes
-    except:
-        num_classes = 20  # default to 20 for backwards compat if missing args.num_classes
-
-    # over-ride num_classes for known datasets:
-    if args.dataset_file == 'coco':
-        num_classes = 91
-
-    if args.dataset_file == 'coco_panoptic':
+    num_classes = 20 if args.dataset_file != 'coco' else 91
+    if args.dataset_file == "coco_panoptic":
         num_classes = 250
-
     device = torch.device(args.device)
 
     backbone = build_backbone(args)
@@ -368,3 +347,4 @@ def build(args):
             postprocessors["panoptic"] = PostProcessPanoptic(is_thing_map, threshold=0.85)
 
     return model, criterion, postprocessors
+    

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -5,6 +5,7 @@ import torch
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
+import numpy as np
 
 from pathlib import Path, PurePath
 
@@ -43,6 +44,15 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
             continue
         raise ValueError(f"{func_name} - invalid directory in logs argument:\n{dir}")
 
+    # check if first log file exists...it will not be present until after epoch 1.
+    fn = Path(logs[0]/log_name)
+    
+    if not fn.exists():
+        print(f"-> missing {log_name} in first directory.  Have you gotten to Epoch 1 in training?")
+        print(f"--> file path: {fn}")
+        return
+
+
     # load log file(s) and plot
     dfs = [pd.read_json(Path(p) / log_name, lines=True) for p in logs]
 
@@ -52,7 +62,7 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
         for j, field in enumerate(fields):
             if field == 'mAP':
                 coco_eval = pd.DataFrame(
-                    pd.np.stack(df.test_coco_eval_bbox.dropna().values)[:, 1]
+                    np.stack(df.test_coco_eval_bbox.dropna().values)[:, 1]
                 ).ewm(com=ewm_col).mean()
                 axs[j].plot(coco_eval, c=color)
             else:

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -45,13 +45,12 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
         raise ValueError(f"{func_name} - invalid directory in logs argument:\n{dir}")
 
     # check if first log file exists...it will not be present until after epoch 1.
-    fn = Path(logs[0]/log_name)
-    
+    fn = Path(logs[0] / log_name)
+
     if not fn.exists():
         print(f"-> missing {log_name} in first directory.  Have you gotten to Epoch 1 in training?")
         print(f"--> file path: {fn}")
         return
-
 
     # load log file(s) and plot
     dfs = [pd.read_json(Path(p) / log_name, lines=True) for p in logs]


### PR DESCRIPTION
This is a PR from https://github.com/facebookresearch/detr/issues/172
Fixes:
1 - Avoids ' FutureWarning: The pandas.np module is deprecated and will be removed from pandas in a future version. Import numpy directly instead' with PyTorch 1.60

2 - Avoids crash if user runs plot_logs before a log.txt has been written (i.e. before epoch 1).  
Now will receive warning noting the {log_name} was not available and hint they might not have one written out yet.  
![missing_log_txt](https://user-images.githubusercontent.com/46302957/89742845-43546800-da52-11ea-9abc-e19eddeb54e8.PNG)
