### PR TITLE
Plot util fixes - future proof, avoid crash if no log.txt

### DIFF
--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -41,14 +41,14 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
         if not isinstance(dir, PurePath):
             raise ValueError(f"{func_name} - non-Path object in logs argument of {type(dir)}: \n{dir}")
         if not dir.exists():
-            raise ValueError(f"{func_name} - invalid directory in logs argument:\n{dir}")          
+            raise ValueError(f"{func_name} - invalid directory in logs argument:\n{dir}")
         # verify log_name exists
         fn = Path(dir / log_name)
         if not fn.exists():
             print(f"-> missing {log_name}.  Have you gotten to Epoch 1 in training?")
             print(f"--> full path of missing log file: {fn}")
             return
-        
+
     # load log file(s) and plot
     dfs = [pd.read_json(Path(p) / log_name, lines=True) for p in logs]
 

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -5,6 +5,7 @@ import torch
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
+import numpy as np
 
 from pathlib import Path, PurePath
 
@@ -43,6 +44,14 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
             continue
         raise ValueError(f"{func_name} - invalid directory in logs argument:\n{dir}")
 
+    # check if first log file exists...it will not be present until after epoch 1.
+    fn = Path(logs[0] / log_name)
+
+    if not fn.exists():
+        print(f"-> missing {log_name} in first directory.  Have you gotten to Epoch 1 in training?")
+        print(f"--> file path: {fn}")
+        return
+
     # load log file(s) and plot
     dfs = [pd.read_json(Path(p) / log_name, lines=True) for p in logs]
 
@@ -52,7 +61,7 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
         for j, field in enumerate(fields):
             if field == 'mAP':
                 coco_eval = pd.DataFrame(
-                    pd.np.stack(df.test_coco_eval_bbox.dropna().values)[:, 1]
+                    np.stack(df.test_coco_eval_bbox.dropna().values)[:, 1]
                 ).ewm(com=ewm_col).mean()
                 axs[j].plot(coco_eval, c=color)
             else:

--- a/util/plot_utils.py
+++ b/util/plot_utils.py
@@ -3,9 +3,9 @@ Plotting utilities to visualize training logs.
 """
 import torch
 import pandas as pd
+import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
-import numpy as np
 
 from pathlib import Path, PurePath
 
@@ -36,22 +36,19 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
             raise ValueError(f"{func_name} - invalid argument for logs parameter.\n \
             Expect list[Path] or single Path obj, received {type(logs)}")
 
-    # verify valid dir(s) and that every item in list is Path object
+    # Quality checks - verify valid dir(s), that every item in list is Path object, and that log_name exists in each dir
     for i, dir in enumerate(logs):
         if not isinstance(dir, PurePath):
             raise ValueError(f"{func_name} - non-Path object in logs argument of {type(dir)}: \n{dir}")
-        if dir.exists():
-            continue
-        raise ValueError(f"{func_name} - invalid directory in logs argument:\n{dir}")
-
-    # check if first log file exists...it will not be present until after epoch 1.
-    fn = Path(logs[0] / log_name)
-
-    if not fn.exists():
-        print(f"-> missing {log_name} in first directory.  Have you gotten to Epoch 1 in training?")
-        print(f"--> file path: {fn}")
-        return
-
+        if not dir.exists():
+            raise ValueError(f"{func_name} - invalid directory in logs argument:\n{dir}")          
+        # verify log_name exists
+        fn = Path(dir / log_name)
+        if not fn.exists():
+            print(f"-> missing {log_name}.  Have you gotten to Epoch 1 in training?")
+            print(f"--> full path of missing log file: {fn}")
+            return
+        
     # load log file(s) and plot
     dfs = [pd.read_json(Path(p) / log_name, lines=True) for p in logs]
 


### PR DESCRIPTION
This is the PR for issue:  https://github.com/facebookresearch/detr/issues/172

1 - Updates with numpy to avoid FutureWarning for those on PyTorch 1.60: 
FutureWarning: The pandas.np module is deprecated and will be removed from pandas in a future version. Import numpy directly instead
pd.np.stack(df.test_coco_eval_bbox.dropna().values)[:, 1]' 

2 - Avoids crash if user runs plot_logs before a log.txt has been written and provides hint as to whether Epoch 1 has finished or not. 
Example of new behaviour if no log file: 
![missing_log_txt](https://user-images.githubusercontent.com/46302957/89743362-7d743880-da57-11ea-973d-ad9dc47f1061.PNG)

