### PR TITLE
Fixed 0-elements bug in forward

### DIFF
--- a/models/segmentation.py
+++ b/models/segmentation.py
@@ -284,7 +284,7 @@ class PostProcessPanoptic(nn.Module):
             cur_scores = cur_scores[keep]
             cur_classes = cur_classes[keep]
             cur_masks = cur_masks[keep]
-            cur_masks = interpolate(cur_masks[None], to_tuple(size), mode="bilinear").squeeze(0)
+            cur_masks = interpolate(cur_masks[:, None], to_tuple(size), mode="bilinear").squeeze(1)
             cur_boxes = box_ops.box_cxcywh_to_xyxy(cur_boxes[keep])
 
             h, w = cur_masks.shape[-2:]


### PR DESCRIPTION
This PR tries to solve the problem that occured when no boxes were passed into the interpolate function, causing the training to fail.