### PR TITLE
Correcting incorrect types

### DIFF
--- a/util/misc.py
+++ b/util/misc.py
@@ -286,7 +286,7 @@ class NestedTensor(object):
         self.mask = mask
 
     def to(self, device):
-        # type: (Device) -> NestedTensor # noqa
+        # type: (torch.device) -> NestedTensor
         cast_tensor = self.tensors.to(device)
         mask = self.mask
         if mask is not None:


### PR DESCRIPTION
Due to torchscript support `torch.device` now, I updated the `Device` to `torch.device`