### PR TITLE
Fixed outdated publication link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ definitions with standard training loops.
 
 Additionnally, we provide a Detectron2 wrapper in the d2/ folder. See the readme there for more information.
 
-For details see [End-to-End Object Detection with Transformers](https://ai.facebook.com/research/publications/end-to-end-object-detection-with-transformers) by Nicolas Carion, Francisco Massa, Gabriel Synnaeve, Nicolas Usunier, Alexander Kirillov, and Sergey Zagoruyko.
+For details see [End-to-End Object Detection with Transformers](https://research.fb.com/publications/end-to-end-object-detection-with-transformers/) by Nicolas Carion, Francisco Massa, Gabriel Synnaeve, Nicolas Usunier, Alexander Kirillov, and Sergey Zagoruyko.
 
 # Model Zoo
 We provide baseline DETR and DETR-DC5 models, and plan to include more in future.


### PR DESCRIPTION
[Link to publication](https://ai.facebook.com/research/publications/end-to-end-object-detection-with-transformers) in README does not work. I believe it is outdated.

I updated the publication link using research.fb.com which can be found [here](https://research.fb.com/publications/end-to-end-object-detection-with-transformers/).

I'm not sure what the old link looked like, but I assume this is the same page, just a newer working link by facebook.