### PR TITLE
Removed a manual indexer iterator pitfall

### DIFF
--- a/test_all.py
+++ b/test_all.py
@@ -168,7 +168,7 @@ class ONNXExporterTester(unittest.TestCase):
         ort_outs = ort_session.run(None, ort_inputs)
         for i in range(0, len(outputs)):
             try:
-                torch.testing.assert_allclose(outputs[i], ort_outs[i], rtol=1e-03, atol=1e-05)
+                torch.testing.assert_allclose(element, ort_outs[i], rtol=1e-03, atol=1e-05)
             except AssertionError as error:
                 if tolerate_small_mismatch:
                     self.assertIn("(0.00%)", str(error), str(error))

--- a/test_all.py
+++ b/test_all.py
@@ -166,7 +166,7 @@ class ONNXExporterTester(unittest.TestCase):
         # compute onnxruntime output prediction
         ort_inputs = dict((ort_session.get_inputs()[i].name, inpt) for i, inpt in enumerate(inputs))
         ort_outs = ort_session.run(None, ort_inputs)
-        for i in range(0, len(outputs)):
+        for i, element in enumerate(outputs):
             try:
                 torch.testing.assert_allclose(element, ort_outs[i], rtol=1e-03, atol=1e-05)
             except AssertionError as error:


### PR DESCRIPTION
**The problem**
The code was iterating on the list 'outputs' manually using
for i, element in enumerate(outputs
```python
for i in range(0, len(outputs)):
```
and accessing the data manually as:
```python
outputs[I]
```
but Python has a built-in manner to deal with it using the method enumerate



```python
for index, element in enumerate(outputs):
```
and thus making the access to the data easier

**The solution**
Changed the manual indexer to the enumerated iterator.