### PR TITLE
Add eval json save in coco result format

### DIFF
--- a/datasets/coco_eval.py
+++ b/datasets/coco_eval.py
@@ -32,6 +32,7 @@ class CocoEvaluator(object):
 
         self.img_ids = []
         self.eval_imgs = {k: [] for k in iou_types}
+        self.coco_json_predictions = []
 
     def update(self, predictions):
         img_ids = list(np.unique(list(predictions.keys())))
@@ -39,6 +40,7 @@ class CocoEvaluator(object):
 
         for iou_type in self.iou_types:
             results = self.prepare(predictions, iou_type)
+            self.coco_json_predictions.extend(results)
 
             # suppress pycocotools prints
             with open(os.devnull, 'w') as devnull:

--- a/main.py
+++ b/main.py
@@ -186,6 +186,7 @@ def main(args):
                                               data_loader_val, base_ds, device, args.output_dir)
         if args.output_dir:
             utils.save_on_master(coco_evaluator.coco_eval["bbox"].eval, output_dir / "eval.pth")
+            utils.save_json(coco_evaluator.coco_json_predictions, output_dir / "results.json")
         return
 
     print("Start training")

--- a/util/misc.py
+++ b/util/misc.py
@@ -10,6 +10,7 @@ import time
 from collections import defaultdict, deque
 import datetime
 import pickle
+import json
 from packaging import version
 from typing import Optional, List
 
@@ -402,6 +403,11 @@ def is_main_process():
 def save_on_master(*args, **kwargs):
     if is_main_process():
         torch.save(*args, **kwargs)
+
+        
+def save_json(results, save_dir):
+    with open(save_dir, 'w') as f:
+        f.write(json.dumps(results))
 
 
 def init_distributed_mode(args):


### PR DESCRIPTION
Add feature to save eval predictions as a json in the coco results format