### PR TITLE
remove unused code

### DIFF
--- a/models/transformer.py
+++ b/models/transformer.py
@@ -112,12 +112,6 @@ class TransformerDecoder(nn.Module):
             if self.return_intermediate:
                 intermediate.append(self.norm(output))
 
-        if self.norm is not None:
-            output = self.norm(output)
-            if self.return_intermediate:
-                intermediate.pop()
-                intermediate.append(output)
-
         if self.return_intermediate:
             return torch.stack(intermediate)
 


### PR DESCRIPTION
It seems that these lines are pointless.

Removing these lines has no effect no matter whether` self.norm` is `None` or not.

Besides, `self.norm` coundn't be `None` otherwise `intermediate.append(self.norm(output))` would throw an error.